### PR TITLE
feat: allow clean merge commits by approvers without second approval

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -52,6 +52,7 @@ type Validator interface {
 type GitHub interface {
 	GetPR(ctx context.Context, owner, name string, number int) (*github.PullRequest, error)
 	CreateCheckRun(ctx context.Context, input githubv4.CreateCheckRunInput) error
+	CompareCommits(ctx context.Context, owner, repo, base, head string) ([]string, error)
 }
 
 type Request struct {

--- a/pkg/controller/merge_commit.go
+++ b/pkg/controller/merge_commit.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github"
+)
+
+// checkMergeCommits checks if commits by approvers are clean merge commits
+// that don't change the PR diff (e.g., "Update branch" on GitHub).
+// If so, it marks them as IsAllowedMergeCommit so the validator can skip
+// the self-approval check for those commits.
+// Only commits where the committer is an approver are checked.
+func (c *Controller) checkMergeCommits(ctx context.Context, logger *slog.Logger, ev *Event, pr *github.PullRequest) {
+	for _, commit := range pr.Commits {
+		if commit.Committer == nil {
+			continue
+		}
+		login := commit.Committer.Login
+		if _, ok := pr.Approvers[login]; !ok {
+			continue
+		}
+		allowed := c.isCleanMergeCommit(ctx, logger, ev, commit)
+		commit.IsAllowedMergeCommit = allowed
+		if !allowed {
+			// Early termination: if any approver commit is not a clean merge,
+			// two approvals will be required regardless, so stop checking.
+			return
+		}
+	}
+}
+
+const maxCompareFiles = 300
+
+// isCleanMergeCommit checks whether a commit is a merge commit whose parents'
+// diffs to the merge commit have no overlapping files (i.e., no conflict resolution).
+func (c *Controller) isCleanMergeCommit(ctx context.Context, logger *slog.Logger, ev *Event, commit *github.Commit) bool {
+	if len(commit.Parents) < 2 { //nolint:mnd
+		return false
+	}
+
+	allFiles := make([]map[string]struct{}, 0, len(commit.Parents))
+	for _, parentSHA := range commit.Parents {
+		files, err := c.gh.CompareCommits(ctx, ev.RepoOwner, ev.RepoName, parentSHA, commit.SHA)
+		if err != nil {
+			// Fail closed: treat API failure as requiring two approvals.
+			logger.Warn("compare commits API failed, requiring two approvals",
+				"error", err, "base", parentSHA, "head", commit.SHA)
+			return false
+		}
+		if len(files) >= maxCompareFiles {
+			// Compare Two Commits API limitation: cannot guarantee all changed files are returned.
+			logger.Info("too many changed files, requiring two approvals",
+				"file_count", len(files), "base", parentSHA, "head", commit.SHA)
+			return false
+		}
+		fileSet := make(map[string]struct{}, len(files))
+		for _, f := range files {
+			fileSet[f] = struct{}{}
+		}
+		allFiles = append(allFiles, fileSet)
+	}
+
+	// Check for overlapping files between any two parent diffs.
+	for i := range allFiles {
+		for j := i + 1; j < len(allFiles); j++ {
+			for file := range allFiles[i] {
+				if _, ok := allFiles[j][file]; ok {
+					logger.Info("overlapping file found between parent diffs, requiring two approvals",
+						"file", file, "commit", commit.SHA)
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}

--- a/pkg/controller/merge_commit.go
+++ b/pkg/controller/merge_commit.go
@@ -40,7 +40,7 @@ func (c *Controller) isCleanMergeCommit(ctx context.Context, logger *slog.Logger
 		return false
 	}
 
-	allFiles := make([]map[string]struct{}, 0, len(commit.Parents))
+	allFiles := make(map[string]struct{})
 	for _, parentSHA := range commit.Parents {
 		files, err := c.gh.CompareCommits(ctx, ev.RepoOwner, ev.RepoName, parentSHA, commit.SHA)
 		if err != nil {
@@ -55,23 +55,13 @@ func (c *Controller) isCleanMergeCommit(ctx context.Context, logger *slog.Logger
 				"file_count", len(files), "base", parentSHA, "head", commit.SHA)
 			return false
 		}
-		fileSet := make(map[string]struct{}, len(files))
 		for _, f := range files {
-			fileSet[f] = struct{}{}
-		}
-		allFiles = append(allFiles, fileSet)
-	}
-
-	// Check for overlapping files between any two parent diffs.
-	for i := range allFiles {
-		for j := i + 1; j < len(allFiles); j++ {
-			for file := range allFiles[i] {
-				if _, ok := allFiles[j][file]; ok {
-					logger.Info("overlapping file found between parent diffs, requiring two approvals",
-						"file", file, "commit", commit.SHA)
-					return false
-				}
+			if _, ok := allFiles[f]; ok {
+				logger.Info("overlapping file found between parent diffs, requiring two approvals",
+					"file", f, "commit", commit.SHA)
+				return false
 			}
+			allFiles[f] = struct{}{}
 		}
 	}
 

--- a/pkg/controller/merge_commit_internal_test.go
+++ b/pkg/controller/merge_commit_internal_test.go
@@ -1,0 +1,283 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shurcooL/githubv4"
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github"
+)
+
+var discardLogger = slog.New(slog.DiscardHandler) //nolint:gochecknoglobals
+
+type mockGitHub struct {
+	compareResult map[string][]string // key: "base...head"
+	compareErr    map[string]error    // key: "base...head"
+}
+
+func (m *mockGitHub) GetPR(_ context.Context, _, _ string, _ int) (*github.PullRequest, error) {
+	return nil, nil
+}
+
+func (m *mockGitHub) CreateCheckRun(_ context.Context, _ githubv4.CreateCheckRunInput) error {
+	return nil
+}
+
+func (m *mockGitHub) CompareCommits(_ context.Context, _, _, base, head string) ([]string, error) {
+	key := base + "..." + head
+	if err, ok := m.compareErr[key]; ok {
+		return nil, err
+	}
+	if files, ok := m.compareResult[key]; ok {
+		return files, nil
+	}
+	return nil, nil
+}
+
+func Test_isCleanMergeCommit(t *testing.T) { //nolint:funlen
+	t.Parallel()
+	tests := []struct {
+		name   string
+		commit *github.Commit
+		mock   *mockGitHub
+		want   bool
+	}{
+		{
+			name: "non-merge commit (single parent)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1"},
+			},
+			mock: &mockGitHub{},
+			want: false,
+		},
+		{
+			name: "non-merge commit (no parents)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: nil,
+			},
+			mock: &mockGitHub{},
+			want: false,
+		},
+		{
+			name: "clean merge commit (no overlapping files)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1", "parent2"},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"parent1...merge123": {"file_a.go", "file_b.go"},
+					"parent2...merge123": {"file_c.go", "file_d.go"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "merge commit with overlapping files (conflict resolution)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1", "parent2"},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"parent1...merge123": {"file_a.go", "file_b.go"},
+					"parent2...merge123": {"file_b.go", "file_c.go"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "compare API failure",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1", "parent2"},
+			},
+			mock: &mockGitHub{
+				compareErr: map[string]error{
+					"parent1...merge123": errors.New("API error"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "too many changed files (>= 300)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1", "parent2"},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"parent1...merge123": make([]string, 300),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "octopus merge (3 parents, no overlap)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1", "parent2", "parent3"},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"parent1...merge123": {"file_a.go"},
+					"parent2...merge123": {"file_b.go"},
+					"parent3...merge123": {"file_c.go"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "octopus merge (3 parents, overlap between non-adjacent)",
+			commit: &github.Commit{
+				SHA:     "merge123",
+				Parents: []string{"parent1", "parent2", "parent3"},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"parent1...merge123": {"file_a.go"},
+					"parent2...merge123": {"file_b.go"},
+					"parent3...merge123": {"file_a.go"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := &Controller{gh: tt.mock}
+			ev := &Event{RepoOwner: "owner", RepoName: "repo"}
+			got := ctrl.isCleanMergeCommit(context.Background(), discardLogger, ev, tt.commit)
+			if got != tt.want {
+				t.Errorf("isCleanMergeCommit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
+	t.Parallel()
+	tests := []struct {
+		name                      string
+		pr                        *github.PullRequest
+		mock                      *mockGitHub
+		wantIsAllowedMergeCommit []bool
+	}{
+		{
+			name: "non-approver commits are skipped",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:       "commit1",
+						Committer: &github.User{Login: "bob"},
+						Parents:   []string{"p1"},
+					},
+				},
+			},
+			mock:                      &mockGitHub{},
+			wantIsAllowedMergeCommit: []bool{false},
+		},
+		{
+			name: "approver clean merge commits marked as allowed",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:       "merge1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p1", "p2"},
+					},
+					{
+						SHA:       "merge2",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p3", "p4"},
+					},
+				},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"p1...merge1": {"a.go"},
+					"p2...merge1": {"b.go"},
+					"p3...merge2": {"c.go"},
+					"p4...merge2": {"d.go"},
+				},
+			},
+			wantIsAllowedMergeCommit: []bool{true, true},
+		},
+		{
+			name: "early termination on non-clean approver commit",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:       "regular",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p1"},
+					},
+					{
+						SHA:       "merge1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p2", "p3"},
+					},
+				},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"p2...merge1": {"a.go"},
+					"p3...merge1": {"b.go"},
+				},
+			},
+			// First commit is not a clean merge (single parent), so early termination.
+			// Second commit is not checked, stays false (default).
+			wantIsAllowedMergeCommit: []bool{false, false},
+		},
+		{
+			name: "nil committer commit is skipped",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:       "commit1",
+						Committer: nil,
+						Parents:   []string{"p1", "p2"},
+					},
+				},
+			},
+			mock:                      &mockGitHub{},
+			wantIsAllowedMergeCommit: []bool{false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := &Controller{gh: tt.mock}
+			ev := &Event{RepoOwner: "owner", RepoName: "repo"}
+			ctrl.checkMergeCommits(context.Background(), discardLogger, ev, tt.pr)
+
+			got := make([]bool, len(tt.pr.Commits))
+			for i, c := range tt.pr.Commits {
+				got[i] = c.IsAllowedMergeCommit
+			}
+			if diff := cmp.Diff(tt.wantIsAllowedMergeCommit, got); diff != "" {
+				t.Errorf("IsAllowedMergeCommit mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/merge_commit_internal_test.go
+++ b/pkg/controller/merge_commit_internal_test.go
@@ -19,7 +19,7 @@ type mockGitHub struct {
 }
 
 func (m *mockGitHub) GetPR(_ context.Context, _, _ string, _ int) (*github.PullRequest, error) {
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 func (m *mockGitHub) CreateCheckRun(_ context.Context, _ githubv4.CreateCheckRunInput) error {

--- a/pkg/controller/merge_commit_internal_test.go
+++ b/pkg/controller/merge_commit_internal_test.go
@@ -165,9 +165,9 @@ func Test_isCleanMergeCommit(t *testing.T) { //nolint:funlen
 func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	tests := []struct {
-		name                      string
-		pr                        *github.PullRequest
-		mock                      *mockGitHub
+		name                     string
+		pr                       *github.PullRequest
+		mock                     *mockGitHub
 		wantIsAllowedMergeCommit []bool
 	}{
 		{
@@ -184,7 +184,7 @@ func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
 					},
 				},
 			},
-			mock:                      &mockGitHub{},
+			mock:                     &mockGitHub{},
 			wantIsAllowedMergeCommit: []bool{false},
 		},
 		{
@@ -259,7 +259,7 @@ func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
 					},
 				},
 			},
-			mock:                      &mockGitHub{},
+			mock:                     &mockGitHub{},
 			wantIsAllowedMergeCommit: []bool{false},
 		},
 	}

--- a/pkg/controller/validate.go
+++ b/pkg/controller/validate.go
@@ -15,6 +15,9 @@ func (c *Controller) validate(ctx context.Context, logger *slog.Logger, ev *Even
 		return &validation.Result{Error: fmt.Errorf("get a pull request: %w", err).Error()}
 	}
 	logger.Info("fetched a pull request", "pull_request", pr)
+
+	c.checkMergeCommits(ctx, logger, ev, pr)
+
 	input := &validation.Input{
 		PR: pr,
 		Trust: &validation.Trust{

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -6,16 +6,22 @@ import (
 
 	"github.com/google/go-github/v84/github"
 	"github.com/shurcooL/githubv4"
+	v3 "github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github/v3"
 	v4 "github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github/v4"
 )
 
 type Client struct {
 	v4Client V4Client
+	v3Client V3Client
 }
 
 type V4Client interface {
 	GetPR(ctx context.Context, owner, name string, number int) (*v4.PullRequest, error)
 	CreateCheckRun(ctx context.Context, input githubv4.CreateCheckRunInput) error
+}
+
+type V3Client interface {
+	CompareCommits(ctx context.Context, owner, repo, base, head string) ([]string, error)
 }
 
 type (
@@ -31,7 +37,17 @@ func New(param *v4.ParamNewApp) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create GitHub v4 client: %w", err)
 	}
+	v3Client, err := v3.New(&v3.ParamNewApp{
+		AppID:          param.AppID,
+		InstallationID: param.InstallationID,
+		KeyFile:        param.KeyFile,
+		Logger:         param.Logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create GitHub v3 client: %w", err)
+	}
 	return &Client{
 		v4Client: v4Client,
+		v3Client: v3Client,
 	}, nil
 }

--- a/pkg/github/commit.go
+++ b/pkg/github/commit.go
@@ -44,3 +44,19 @@ type Commit struct {
 func (c *Commit) Linked() bool {
 	return c.Committer != nil && c.Committer.Login != ""
 }
+
+func newCommit(pc *v4.PullRequestCommit) *Commit {
+	var parents []string
+	if pc.Commit.Parents != nil {
+		parents = make([]string, len(pc.Commit.Parents.Nodes))
+		for i, p := range pc.Commit.Parents.Nodes {
+			parents[i] = p.OID
+		}
+	}
+	return &Commit{
+		SHA:       pc.Commit.OID,
+		Committer: newUser(pc.Commit.User()),
+		Signature: pc.Commit.Signature,
+		Parents:   parents,
+	}
+}

--- a/pkg/github/commit.go
+++ b/pkg/github/commit.go
@@ -34,9 +34,11 @@ func (c *UntrustedCommit) Message() string {
 }
 
 type Commit struct {
-	SHA       string        `json:"oid"`
-	Committer *User         `json:"committer"`
-	Signature *v4.Signature `json:"signature"`
+	SHA                  string        `json:"oid"`
+	Committer            *User         `json:"committer"`
+	Signature            *v4.Signature `json:"signature"`
+	Parents              []string      `json:"parents"`
+	IsAllowedMergeCommit bool          `json:"is_allowed_merge_commit"`
 }
 
 func (c *Commit) Linked() bool {

--- a/pkg/github/compare.go
+++ b/pkg/github/compare.go
@@ -1,0 +1,8 @@
+package github
+
+import "context"
+
+// CompareCommits returns the list of changed file paths between two commits.
+func (c *Client) CompareCommits(ctx context.Context, owner, repo, base, head string) ([]string, error) {
+	return c.v3Client.CompareCommits(ctx, owner, repo, base, head)
+}

--- a/pkg/github/compare.go
+++ b/pkg/github/compare.go
@@ -1,8 +1,15 @@
 package github
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // CompareCommits returns the list of changed file paths between two commits.
 func (c *Client) CompareCommits(ctx context.Context, owner, repo, base, head string) ([]string, error) {
-	return c.v3Client.CompareCommits(ctx, owner, repo, base, head)
+	files, err := c.v3Client.CompareCommits(ctx, owner, repo, base, head)
+	if err != nil {
+		return nil, fmt.Errorf("compare commits: %w", err)
+	}
+	return files, nil
 }

--- a/pkg/github/get_pr.go
+++ b/pkg/github/get_pr.go
@@ -16,10 +16,18 @@ func (c *Client) GetPR(ctx context.Context, owner, name string, number int) (*Pu
 	}
 	commits := make([]*Commit, len(pr.Commits.Nodes))
 	for i, v := range pr.Commits.Nodes {
+		var parents []string
+		if v.Commit.Parents != nil {
+			parents = make([]string, len(v.Commit.Parents.Nodes))
+			for j, p := range v.Commit.Parents.Nodes {
+				parents[j] = p.OID
+			}
+		}
 		commits[i] = &Commit{
 			SHA:       v.Commit.OID,
 			Committer: newUser(v.Commit.User()),
 			Signature: v.Commit.Signature,
+			Parents:   parents,
 		}
 	}
 	// filter reviews

--- a/pkg/github/get_pr.go
+++ b/pkg/github/get_pr.go
@@ -16,19 +16,7 @@ func (c *Client) GetPR(ctx context.Context, owner, name string, number int) (*Pu
 	}
 	commits := make([]*Commit, len(pr.Commits.Nodes))
 	for i, v := range pr.Commits.Nodes {
-		var parents []string
-		if v.Commit.Parents != nil {
-			parents = make([]string, len(v.Commit.Parents.Nodes))
-			for j, p := range v.Commit.Parents.Nodes {
-				parents[j] = p.OID
-			}
-		}
-		commits[i] = &Commit{
-			SHA:       v.Commit.OID,
-			Committer: newUser(v.Commit.User()),
-			Signature: v.Commit.Signature,
-			Parents:   parents,
-		}
+		commits[i] = newCommit(v)
 	}
 	// filter reviews
 	// Get the latest review for each user

--- a/pkg/github/v3/client.go
+++ b/pkg/github/v3/client.go
@@ -1,0 +1,35 @@
+package v3
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/google/go-github/v84/github"
+	"github.com/suzuki-shunsuke/go-retryablehttp"
+)
+
+type Client struct {
+	client *github.Client
+}
+
+type ParamNewApp struct {
+	AppID          int64
+	KeyFile        string
+	InstallationID int64
+	Logger         *slog.Logger
+}
+
+func New(param *ParamNewApp) (*Client, error) {
+	itr, err := ghinstallation.New(http.DefaultTransport, param.AppID, param.InstallationID, []byte(param.KeyFile))
+	if err != nil {
+		return nil, fmt.Errorf("create a transport with private key: %w", err)
+	}
+	c := retryablehttp.NewClient()
+	c.HTTPClient = &http.Client{Transport: itr}
+	c.Logger = param.Logger
+	return &Client{
+		client: github.NewClient(c.StandardClient()),
+	}, nil
+}

--- a/pkg/github/v3/compare.go
+++ b/pkg/github/v3/compare.go
@@ -1,0 +1,19 @@
+package v3
+
+import (
+	"context"
+	"fmt"
+)
+
+// CompareCommits compares two commits and returns the list of changed file paths.
+func (c *Client) CompareCommits(ctx context.Context, owner, repo, base, head string) ([]string, error) {
+	comp, _, err := c.client.Repositories.CompareCommits(ctx, owner, repo, base, head, nil)
+	if err != nil {
+		return nil, fmt.Errorf("compare commits %s...%s: %w", base, head, err)
+	}
+	files := make([]string, len(comp.Files))
+	for i, f := range comp.Files {
+		files[i] = f.GetFilename()
+	}
+	return files, nil
+}

--- a/pkg/github/v4/commit.go
+++ b/pkg/github/v4/commit.go
@@ -9,6 +9,15 @@ type Commit struct {
 	Committer *Committer `json:"committer"`
 	Author    *Committer `json:"author"`
 	Signature *Signature `json:"signature"`
+	Parents   *Parents   `json:"parents" graphql:"parents(first:10)"`
+}
+
+type Parents struct {
+	Nodes []*ParentCommit `json:"nodes"`
+}
+
+type ParentCommit struct {
+	OID string `json:"oid"`
 }
 
 type Signature struct {

--- a/pkg/validation/run.go
+++ b/pkg/validation/run.go
@@ -69,8 +69,10 @@ func (c *Validator) Run(_ *slog.Logger, input *Input) *Result { //nolint:cyclop
 		}
 		committer := commit.Committer
 		login := committer.Login
-		if _, ok := approvers[login]; ok {
-			// Only one approval is given, but it's a self approval
+		if _, ok := approvers[login]; ok && !commit.IsAllowedMergeCommit {
+			// Only one approval is given, but it's a self approval.
+			// Clean merge commits (e.g., "Update branch") are excluded
+			// from the self-approval check.
 			result.SelfApprover = login
 		}
 	}

--- a/pkg/validation/run_test.go
+++ b/pkg/validation/run_test.go
@@ -527,6 +527,86 @@ func TestController_Run(t *testing.T) {
 			},
 		},
 		{
+			name:     "one approval with self approval but allowed merge commit - approved",
+			inputNew: &validation.InputNew{},
+			input: &validation.Input{
+				Trust: &validation.Trust{
+					TrustedApps: map[string]struct{}{},
+				},
+				PR: &github.PullRequest{
+					HeadSHA: "abc123",
+					Approvers: map[string]*github.User{
+						"committer": {Login: "committer"},
+					},
+					Commits: []*github.Commit{
+						{
+							SHA: "abc123",
+							Committer: &github.User{
+								Login: "committer",
+								IsApp: false,
+							},
+							Signature: &github.Signature{
+								IsValid: true,
+								State:   "valid",
+							},
+							Parents:              []string{"parent1", "parent2"},
+							IsAllowedMergeCommit: true,
+						},
+					},
+				},
+			},
+			expected: &validation.Result{
+				State:     validation.StateApproved,
+				Approvers: []string{"committer"},
+			},
+		},
+		{
+			name:     "one approval with regular and allowed merge commits - two approvals required",
+			inputNew: &validation.InputNew{},
+			input: &validation.Input{
+				Trust: &validation.Trust{
+					TrustedApps: map[string]struct{}{},
+				},
+				PR: &github.PullRequest{
+					HeadSHA: "abc123",
+					Approvers: map[string]*github.User{
+						"committer": {Login: "committer"},
+					},
+					Commits: []*github.Commit{
+						{
+							SHA: "regular1",
+							Committer: &github.User{
+								Login: "committer",
+								IsApp: false,
+							},
+							Signature: &github.Signature{
+								IsValid: true,
+								State:   "valid",
+							},
+							Parents: []string{"parent1"},
+						},
+						{
+							SHA: "merge1",
+							Committer: &github.User{
+								Login: "committer",
+								IsApp: false,
+							},
+							Signature: &github.Signature{
+								IsValid: true,
+								State:   "valid",
+							},
+							Parents:              []string{"parent2", "parent3"},
+							IsAllowedMergeCommit: true,
+						},
+					},
+				},
+			},
+			expected: &validation.Result{
+				State:        validation.StateTwoApprovalsAreRequired,
+				SelfApprover: "committer",
+			},
+		},
+		{
 			name:     "one approval with commit not linked to user - two approvals required",
 			inputNew: &validation.InputNew{},
 			input: &validation.Input{


### PR DESCRIPTION
## Summary

When an approver clicks "Update branch" on GitHub, a merge commit is created. Currently this triggers the two-approval requirement because the approver has committed to the PR. This is overly strict — an "Update branch" that doesn't change the PR diff can't introduce malicious changes.

This PR allows clean merge commits (no conflict resolution) by approvers to bypass the two-approval requirement, improving developer experience without compromising security.

## Changes

### GraphQL query: fetch parent commit SHAs
- Added `Parents`, `ParentCommit` types to `pkg/github/v4/commit.go` with `parents(first:10)` GraphQL field
- Added `Parents []string` and `IsAllowedMergeCommit bool` fields to the domain `Commit` struct in `pkg/github/commit.go`
- Updated `pkg/github/get_pr.go` to extract parent OIDs during commit conversion

### REST API (v3) client for Compare Two Commits API
- Created `pkg/github/v3/client.go` — REST API client using `google/go-github/v84` with the same auth pattern as the v4 client (`ghinstallation` + `retryablehttp`)
- Created `pkg/github/v3/compare.go` — `CompareCommits` method that returns changed file paths
- Integrated the v3 client into the wrapper `pkg/github/client.go` (new `V3Client` interface, updated `New()`)
- Created `pkg/github/compare.go` — pass-through method on the wrapper Client

### Merge commit checking logic
- Created `pkg/controller/merge_commit.go` with two functions:
  - `checkMergeCommits`: iterates PR commits, **only checks commits where the committer is an approver**, marks clean merge commits with `IsAllowedMergeCommit = true`. Implements early termination — stops as soon as any approver commit is not a clean merge
  - `isCleanMergeCommit`: checks if a commit is a merge commit (`len(parents) >= 2`) whose parent diffs have no overlapping files (by file path). Handles fail-closed on API errors and the 300-file API limitation
- Updated `pkg/controller/validate.go` to call `checkMergeCommits` after fetching the PR and before running validation
- Added `CompareCommits` to the `GitHub` interface in `pkg/controller/controller.go`

### Validation logic update
- Updated `pkg/validation/run.go` to skip the self-approval check for commits marked as `IsAllowedMergeCommit`

### Tests
- Created `pkg/controller/merge_commit_internal_test.go` with tests for:
  - `isCleanMergeCommit`: non-merge commit, clean merge, overlapping files, API failure, >= 300 files, octopus merge (3 parents), overlap between non-adjacent parents
  - `checkMergeCommits`: non-approver commits skipped, approver clean merges marked, early termination on non-clean commit, nil committer handling
- Added 2 test cases to `pkg/validation/run_test.go`:
  - Allowed merge commit by approver → `StateApproved`
  - Regular commit + allowed merge commit by same approver → `StateTwoApprovalsAreRequired`

## Design decisions

- **Fail closed**: Compare API failures and responses with >= 300 files are treated as requiring two approvals
- **Overlap detection**: Based on file path only (conservative — even auto-merged same-file changes require two approvals)
- **Early termination**: Stops Compare API calls as soon as any approver commit requires two approvals
- **Separation of concerns**: Merge commit checking happens in the controller (pre-processing), keeping the validator pure (no API calls)

## Test plan

- [x] `cmdx v` passes (go vet)
- [x] `cmdx t` passes (all tests)
- [x] Deploy to staging and test with a PR where the approver clicks "Update branch"
- [x] Verify that conflict resolution merges still require two approvals

🤖 Generated with [Claude Code](https://claude.com/claude-code)