### PR TITLE
feat: allow approver's empty commits without second approval

### DIFF
--- a/pkg/controller/merge_commit.go
+++ b/pkg/controller/merge_commit.go
@@ -7,18 +7,22 @@ import (
 	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github"
 )
 
-// checkMergeCommits checks if commits by approvers are clean merge commits
-// that don't change the PR diff (e.g., "Update branch" on GitHub).
-// If so, it marks them as IsAllowedMergeCommit so the validator can skip
-// the self-approval check for those commits.
+// checkApproverCommits checks if commits by approvers are harmless
+// (empty commits or clean merge commits) and marks them as IsAllowedMergeCommit
+// so the validator can skip the self-approval check for those commits.
 // Only commits where the committer is an approver are checked.
-func (c *Controller) checkMergeCommits(ctx context.Context, logger *slog.Logger, ev *Event, pr *github.PullRequest) {
+func (c *Controller) checkApproverCommits(ctx context.Context, logger *slog.Logger, ev *Event, pr *github.PullRequest) {
 	for _, commit := range pr.Commits {
 		if commit.Committer == nil {
 			continue
 		}
 		login := commit.Committer.Login
 		if _, ok := pr.Approvers[login]; !ok {
+			continue
+		}
+		// Empty commits (0 changed files) cannot introduce malicious changes.
+		if commit.ChangedFilesIfAvailable != nil && *commit.ChangedFilesIfAvailable == 0 {
+			commit.IsAllowedMergeCommit = true
 			continue
 		}
 		allowed := c.isCleanMergeCommit(ctx, logger, ev, commit)

--- a/pkg/controller/merge_commit_internal_test.go
+++ b/pkg/controller/merge_commit_internal_test.go
@@ -162,7 +162,11 @@ func Test_isCleanMergeCommit(t *testing.T) { //nolint:funlen
 	}
 }
 
-func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
+func intPtr(v int) *int {
+	return &v
+}
+
+func Test_checkApproverCommits(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	tests := []struct {
 		name                     string
@@ -262,6 +266,87 @@ func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
 			mock:                     &mockGitHub{},
 			wantIsAllowedMergeCommit: []bool{false},
 		},
+		{
+			name: "approver empty commit (single parent) is allowed",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:                     "empty1",
+						Committer:               &github.User{Login: "alice"},
+						Parents:                 []string{"p1"},
+						ChangedFilesIfAvailable: intPtr(0),
+					},
+				},
+			},
+			mock:                     &mockGitHub{},
+			wantIsAllowedMergeCommit: []bool{true},
+		},
+		{
+			name: "approver empty merge commit is allowed without Compare API",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:                     "empty-merge1",
+						Committer:               &github.User{Login: "alice"},
+						Parents:                 []string{"p1", "p2"},
+						ChangedFilesIfAvailable: intPtr(0),
+					},
+				},
+			},
+			// No compareResult needed — empty commit check short-circuits before Compare API.
+			mock:                     &mockGitHub{},
+			wantIsAllowedMergeCommit: []bool{true},
+		},
+		{
+			name: "approver commit with nil changedFilesIfAvailable is not allowed (fail closed)",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:                     "commit1",
+						Committer:               &github.User{Login: "alice"},
+						Parents:                 []string{"p1"},
+						ChangedFilesIfAvailable: nil,
+					},
+				},
+			},
+			mock:                     &mockGitHub{},
+			wantIsAllowedMergeCommit: []bool{false},
+		},
+		{
+			name: "approver non-empty single-parent commit triggers early termination",
+			pr: &github.PullRequest{
+				Approvers: map[string]*github.User{
+					"alice": {Login: "alice"},
+				},
+				Commits: []*github.Commit{
+					{
+						SHA:                     "nonempty1",
+						Committer:               &github.User{Login: "alice"},
+						Parents:                 []string{"p1"},
+						ChangedFilesIfAvailable: intPtr(5),
+					},
+					{
+						SHA:                     "empty1",
+						Committer:               &github.User{Login: "alice"},
+						Parents:                 []string{"p2"},
+						ChangedFilesIfAvailable: intPtr(0),
+					},
+				},
+			},
+			mock: &mockGitHub{},
+			// First commit is non-empty single-parent → early termination.
+			// Second commit is not checked.
+			wantIsAllowedMergeCommit: []bool{false, false},
+		},
 	}
 
 	for _, tt := range tests {
@@ -269,7 +354,7 @@ func Test_checkMergeCommits(t *testing.T) { //nolint:funlen
 			t.Parallel()
 			ctrl := &Controller{gh: tt.mock}
 			ev := &Event{RepoOwner: "owner", RepoName: "repo"}
-			ctrl.checkMergeCommits(context.Background(), discardLogger, ev, tt.pr)
+			ctrl.checkApproverCommits(context.Background(), discardLogger, ev, tt.pr)
 
 			got := make([]bool, len(tt.pr.Commits))
 			for i, c := range tt.pr.Commits {

--- a/pkg/controller/merge_commit_internal_test.go
+++ b/pkg/controller/merge_commit_internal_test.go
@@ -162,10 +162,6 @@ func Test_isCleanMergeCommit(t *testing.T) { //nolint:funlen
 	}
 }
 
-func intPtr(v int) *int {
-	return &v
-}
-
 func Test_checkApproverCommits(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	tests := []struct {
@@ -277,7 +273,7 @@ func Test_checkApproverCommits(t *testing.T) { //nolint:funlen
 						SHA:                     "empty1",
 						Committer:               &github.User{Login: "alice"},
 						Parents:                 []string{"p1"},
-						ChangedFilesIfAvailable: intPtr(0),
+						ChangedFilesIfAvailable: new(0),
 					},
 				},
 			},
@@ -295,7 +291,7 @@ func Test_checkApproverCommits(t *testing.T) { //nolint:funlen
 						SHA:                     "empty-merge1",
 						Committer:               &github.User{Login: "alice"},
 						Parents:                 []string{"p1", "p2"},
-						ChangedFilesIfAvailable: intPtr(0),
+						ChangedFilesIfAvailable: new(0),
 					},
 				},
 			},
@@ -332,13 +328,13 @@ func Test_checkApproverCommits(t *testing.T) { //nolint:funlen
 						SHA:                     "nonempty1",
 						Committer:               &github.User{Login: "alice"},
 						Parents:                 []string{"p1"},
-						ChangedFilesIfAvailable: intPtr(5),
+						ChangedFilesIfAvailable: new(5),
 					},
 					{
 						SHA:                     "empty1",
 						Committer:               &github.User{Login: "alice"},
 						Parents:                 []string{"p2"},
-						ChangedFilesIfAvailable: intPtr(0),
+						ChangedFilesIfAvailable: new(0),
 					},
 				},
 			},

--- a/pkg/controller/validate.go
+++ b/pkg/controller/validate.go
@@ -16,7 +16,7 @@ func (c *Controller) validate(ctx context.Context, logger *slog.Logger, ev *Even
 	}
 	logger.Info("fetched a pull request", "pull_request", pr)
 
-	c.checkMergeCommits(ctx, logger, ev, pr)
+	c.checkApproverCommits(ctx, logger, ev, pr)
 
 	input := &validation.Input{
 		PR: pr,

--- a/pkg/github/commit.go
+++ b/pkg/github/commit.go
@@ -34,11 +34,12 @@ func (c *UntrustedCommit) Message() string {
 }
 
 type Commit struct {
-	SHA                  string        `json:"oid"`
-	Committer            *User         `json:"committer"`
-	Signature            *v4.Signature `json:"signature"`
-	Parents              []string      `json:"parents"`
-	IsAllowedMergeCommit bool          `json:"is_allowed_merge_commit"`
+	SHA                     string        `json:"oid"`
+	Committer               *User         `json:"committer"`
+	Signature               *v4.Signature `json:"signature"`
+	Parents                 []string      `json:"parents"`
+	ChangedFilesIfAvailable *int          `json:"changed_files_if_available"`
+	IsAllowedMergeCommit    bool          `json:"is_allowed_merge_commit"`
 }
 
 func (c *Commit) Linked() bool {
@@ -54,9 +55,10 @@ func newCommit(pc *v4.PullRequestCommit) *Commit {
 		}
 	}
 	return &Commit{
-		SHA:       pc.Commit.OID,
-		Committer: newUser(pc.Commit.User()),
-		Signature: pc.Commit.Signature,
-		Parents:   parents,
+		SHA:                     pc.Commit.OID,
+		Committer:               newUser(pc.Commit.User()),
+		Signature:               pc.Commit.Signature,
+		Parents:                 parents,
+		ChangedFilesIfAvailable: pc.Commit.ChangedFilesIfAvailable,
 	}
 }

--- a/pkg/github/v4/commit.go
+++ b/pkg/github/v4/commit.go
@@ -5,11 +5,11 @@ type PullRequestCommit struct {
 }
 
 type Commit struct {
-	OID                    string     `json:"oid"`
-	Committer              *Committer `json:"committer"`
-	Author                 *Committer `json:"author"`
-	Signature              *Signature `json:"signature"`
-	Parents                *Parents   `json:"parents" graphql:"parents(first:10)"`
+	OID                     string     `json:"oid"`
+	Committer               *Committer `json:"committer"`
+	Author                  *Committer `json:"author"`
+	Signature               *Signature `json:"signature"`
+	Parents                 *Parents   `json:"parents" graphql:"parents(first:10)"`
 	ChangedFilesIfAvailable *int       `json:"changedFilesIfAvailable"`
 }
 

--- a/pkg/github/v4/commit.go
+++ b/pkg/github/v4/commit.go
@@ -5,11 +5,12 @@ type PullRequestCommit struct {
 }
 
 type Commit struct {
-	OID       string     `json:"oid"`
-	Committer *Committer `json:"committer"`
-	Author    *Committer `json:"author"`
-	Signature *Signature `json:"signature"`
-	Parents   *Parents   `json:"parents" graphql:"parents(first:10)"`
+	OID                    string     `json:"oid"`
+	Committer              *Committer `json:"committer"`
+	Author                 *Committer `json:"author"`
+	Signature              *Signature `json:"signature"`
+	Parents                *Parents   `json:"parents" graphql:"parents(first:10)"`
+	ChangedFilesIfAvailable *int       `json:"changedFilesIfAvailable"`
 }
 
 type Parents struct {

--- a/pkg/validation/run_test.go
+++ b/pkg/validation/run_test.go
@@ -607,6 +607,40 @@ func TestController_Run(t *testing.T) {
 			},
 		},
 		{
+			name:     "one approval with self approval but allowed empty commit - approved",
+			inputNew: &validation.InputNew{},
+			input: &validation.Input{
+				Trust: &validation.Trust{
+					TrustedApps: map[string]struct{}{},
+				},
+				PR: &github.PullRequest{
+					HeadSHA: "abc123",
+					Approvers: map[string]*github.User{
+						"committer": {Login: "committer"},
+					},
+					Commits: []*github.Commit{
+						{
+							SHA: "abc123",
+							Committer: &github.User{
+								Login: "committer",
+								IsApp: false,
+							},
+							Signature: &github.Signature{
+								IsValid: true,
+								State:   "valid",
+							},
+							Parents:              []string{"parent1"},
+							IsAllowedMergeCommit: true, // marked by controller as empty commit
+						},
+					},
+				},
+			},
+			expected: &validation.Result{
+				State:     validation.StateApproved,
+				Approvers: []string{"committer"},
+			},
+		},
+		{
 			name:     "one approval with commit not linked to user - two approvals required",
 			inputNew: &validation.InputNew{},
 			input: &validation.Input{


### PR DESCRIPTION
## Summary

When an approver's commit has 0 changed files (`changedFilesIfAvailable == 0`), it cannot introduce malicious changes, so the two-approval requirement is skipped. This complements the existing clean merge commit allowance added in #415.

### Changes

- **`pkg/github/v4/commit.go`**: Add `ChangedFilesIfAvailable *int` field to the GraphQL `Commit` struct, fetched automatically via the GraphQL API
- **`pkg/github/commit.go`**: Add `ChangedFilesIfAvailable *int` to the domain `Commit` struct and propagate in `newCommit()`
- **`pkg/controller/merge_commit.go`**: Rename `checkMergeCommits` → `checkApproverCommits` and add empty commit check *before* the merge commit check:
  - If `changedFilesIfAvailable != nil && *changedFilesIfAvailable == 0` → mark as allowed, skip Compare API call
  - If `changedFilesIfAvailable` is `nil` (GitHub couldn't calculate) → fail closed, fall through to merge commit check
- **`pkg/controller/validate.go`**: Update call site to use renamed `checkApproverCommits`
- **`pkg/controller/merge_commit_internal_test.go`**: Add 4 test cases for empty commits (single parent allowed, merge commit allowed without API, nil fail-closed, early termination)
- **`pkg/validation/run_test.go`**: Add test case for approver empty commit → `StateApproved`

### Design decisions

- **No additional API calls**: Uses `changedFilesIfAvailable` from the existing GraphQL query, unlike the merge commit check which requires REST API calls
- **Fail closed on null**: When GitHub can't calculate the changed files count (returns null), treat conservatively as non-empty
- **Empty check before merge check**: An empty merge commit short-circuits before the Compare API is called, saving API quota
- **Reuses `IsAllowedMergeCommit` field**: Both empty commits and clean merge commits share the same semantic ("approver commit that doesn't require second approval"), so they reuse the same flag

## Test plan

- [x] `cmdx v` passes (go vet)
- [x] `cmdx t` passes (all tests)
- [x] New test: approver empty commit (single parent, changedFiles=0) → allowed
- [x] New test: approver empty merge commit (two parents, changedFiles=0) → allowed without Compare API
- [x] New test: approver commit with nil changedFilesIfAvailable → not allowed (fail closed)
- [x] New test: approver non-empty single-parent commit → early termination
- [x] New test: validation approver empty commit → StateApproved

🤖 Generated with [Claude Code](https://claude.com/claude-code)