### PR TITLE
feat: carry forward check on empty/clean merge commits

### DIFF
--- a/pkg/controller/carry_forward.go
+++ b/pkg/controller/carry_forward.go
@@ -1,0 +1,93 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/config"
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github"
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/validation"
+)
+
+// carryForwardCheck handles pull_request.synchronize events.
+// When new commits are pushed that are all empty or clean merge commits,
+// carry forward the validation result from the most recent reviewed commit.
+func (c *Controller) carryForwardCheck(ctx context.Context, logger *slog.Logger, ev *Event, trust *config.Trust, insecure *config.Insecure) *validation.Result {
+	pr, err := c.gh.GetPR(ctx, ev.RepoOwner, ev.RepoName, ev.PRNumber)
+	if err != nil {
+		return &validation.Result{Error: fmt.Errorf("get a pull request: %w", err).Error()}
+	}
+	logger.Info("fetched a pull request for carry-forward check", "pull_request", pr)
+
+	// Guard against stale webhook redeliveries.
+	if ev.HeadSHA != pr.HeadSHA {
+		logger.Info("ignoring stale webhook: event SHA does not match current PR HEAD",
+			"event_sha", ev.HeadSHA, "head_sha", pr.HeadSHA)
+		return nil
+	}
+
+	approvers := c.findCarryForwardApprovers(ctx, logger, ev, pr)
+	if approvers == nil {
+		return nil
+	}
+
+	// Use the carried-forward approvers for validation.
+	pr.Approvers = approvers
+	c.checkApproverCommits(ctx, logger, ev, pr)
+
+	input := &validation.Input{
+		PR: pr,
+		Trust: &validation.Trust{
+			TrustedApps:           trust.UniqueTrustedApps,
+			UntrustedMachineUsers: trust.UntrustedMachineUsers,
+		},
+	}
+	if insecure != nil {
+		input.Insecure = &validation.Insecure{
+			AllowUnsignedCommits:       insecure.AllowUnsignedCommits != nil && *insecure.AllowUnsignedCommits,
+			UnsignedCommitApps:         toSet(insecure.UnsignedCommitApps),
+			UnsignedCommitMachineUsers: toSet(insecure.UnsignedCommitMachineUsers),
+		}
+	}
+	result := c.validator.Run(logger, input)
+	result.CarriedForward = true
+	return result
+}
+
+// findCarryForwardApprovers walks PR commits from HEAD (newest) to oldest.
+// For each commit, it checks whether the commit is "harmless" (empty or clean merge).
+// When a commit with reviews is found, its approvers are returned.
+// Returns nil if carry-forward is not applicable.
+func (c *Controller) findCarryForwardApprovers(ctx context.Context, logger *slog.Logger, ev *Event, pr *github.PullRequest) map[string]*github.User {
+	// Walk commits from newest to oldest.
+	for i := len(pr.Commits) - 1; i >= 0; i-- {
+		commit := pr.Commits[i]
+
+		// Check if this commit has reviews.
+		if approvers, ok := pr.ApproversByCommit[commit.SHA]; ok && len(approvers) > 0 {
+			logger.Info("found reviewed commit for carry-forward",
+				"commit", commit.SHA, "approver_count", len(approvers))
+			return approvers
+		}
+
+		// Check if this commit is harmless (empty or clean merge).
+		if commit.ChangedFilesIfAvailable != nil && *commit.ChangedFilesIfAvailable == 0 {
+			logger.Info("commit is empty, continuing carry-forward walk", "commit", commit.SHA)
+			continue
+		}
+		if c.isCleanMergeCommit(ctx, logger, ev, commit) {
+			logger.Info("commit is a clean merge, continuing carry-forward walk", "commit", commit.SHA)
+			continue
+		}
+
+		// Commit is not harmless — can't carry forward.
+		logger.Info("commit is not empty or clean merge, carry-forward not applicable",
+			"commit", commit.SHA)
+		return nil
+	}
+
+	// No commit with reviews found.
+	logger.Info("no reviewed commit found, carry-forward not applicable")
+	return nil
+}

--- a/pkg/controller/carry_forward_internal_test.go
+++ b/pkg/controller/carry_forward_internal_test.go
@@ -1,0 +1,237 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/github"
+)
+
+func Test_findCarryForwardApprovers(t *testing.T) { //nolint:funlen
+	t.Parallel()
+	tests := []struct {
+		name string
+		pr   *github.PullRequest
+		mock *mockGitHub
+		want map[string]*github.User
+	}{
+		{
+			name: "HEAD is empty commit, previous commit has review",
+			pr: &github.PullRequest{
+				HeadSHA: "empty1",
+				Commits: []*github.Commit{
+					{
+						SHA:       "reviewed1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p0"},
+					},
+					{
+						SHA:                     "empty1",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"reviewed1"},
+						ChangedFilesIfAvailable: new(0),
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{
+					"reviewed1": {
+						"carol": {Login: "carol"},
+					},
+				},
+			},
+			mock: &mockGitHub{},
+			want: map[string]*github.User{
+				"carol": {Login: "carol"},
+			},
+		},
+		{
+			name: "HEAD is clean merge commit, previous commit has review",
+			pr: &github.PullRequest{
+				HeadSHA: "merge1",
+				Commits: []*github.Commit{
+					{
+						SHA:       "reviewed1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p0"},
+					},
+					{
+						SHA:       "merge1",
+						Committer: &github.User{Login: "bob"},
+						Parents:   []string{"reviewed1", "main-tip"},
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{
+					"reviewed1": {
+						"carol": {Login: "carol"},
+					},
+				},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"reviewed1...merge1": {"file_a.go"},
+					"main-tip...merge1":  {"file_b.go"},
+				},
+			},
+			want: map[string]*github.User{
+				"carol": {Login: "carol"},
+			},
+		},
+		{
+			name: "HEAD is regular commit (non-empty, non-merge)",
+			pr: &github.PullRequest{
+				HeadSHA: "regular1",
+				Commits: []*github.Commit{
+					{
+						SHA:       "reviewed1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p0"},
+					},
+					{
+						SHA:                     "regular1",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"reviewed1"},
+						ChangedFilesIfAvailable: new(5),
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{
+					"reviewed1": {
+						"carol": {Login: "carol"},
+					},
+				},
+			},
+			mock: &mockGitHub{},
+			want: nil,
+		},
+		{
+			name: "HEAD is empty, no commit has reviews",
+			pr: &github.PullRequest{
+				HeadSHA: "empty1",
+				Commits: []*github.Commit{
+					{
+						SHA:                     "commit1",
+						Committer:               &github.User{Login: "alice"},
+						Parents:                 []string{"p0"},
+						ChangedFilesIfAvailable: new(0),
+					},
+					{
+						SHA:                     "empty1",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"commit1"},
+						ChangedFilesIfAvailable: new(0),
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{},
+			},
+			mock: &mockGitHub{},
+			want: nil,
+		},
+		{
+			name: "multiple empty/merge commits walk back to reviewed commit",
+			pr: &github.PullRequest{
+				HeadSHA: "empty3",
+				Commits: []*github.Commit{
+					{
+						SHA:       "reviewed1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p0"},
+					},
+					{
+						SHA:                     "empty1",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"reviewed1"},
+						ChangedFilesIfAvailable: new(0),
+					},
+					{
+						SHA:                     "empty2",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"empty1"},
+						ChangedFilesIfAvailable: new(0),
+					},
+					{
+						SHA:                     "empty3",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"empty2"},
+						ChangedFilesIfAvailable: new(0),
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{
+					"reviewed1": {
+						"carol": {Login: "carol"},
+					},
+				},
+			},
+			mock: &mockGitHub{},
+			want: map[string]*github.User{
+				"carol": {Login: "carol"},
+			},
+		},
+		{
+			name: "conflict-resolution merge commit blocks carry-forward",
+			pr: &github.PullRequest{
+				HeadSHA: "conflict-merge1",
+				Commits: []*github.Commit{
+					{
+						SHA:       "reviewed1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p0"},
+					},
+					{
+						SHA:       "conflict-merge1",
+						Committer: &github.User{Login: "bob"},
+						Parents:   []string{"reviewed1", "main-tip"},
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{
+					"reviewed1": {
+						"carol": {Login: "carol"},
+					},
+				},
+			},
+			mock: &mockGitHub{
+				compareResult: map[string][]string{
+					"reviewed1...conflict-merge1": {"file_a.go", "file_b.go"},
+					"main-tip...conflict-merge1":  {"file_b.go", "file_c.go"}, // overlap on file_b.go
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "nil changedFilesIfAvailable with single parent blocks carry-forward",
+			pr: &github.PullRequest{
+				HeadSHA: "unknown1",
+				Commits: []*github.Commit{
+					{
+						SHA:       "reviewed1",
+						Committer: &github.User{Login: "alice"},
+						Parents:   []string{"p0"},
+					},
+					{
+						SHA:                     "unknown1",
+						Committer:               &github.User{Login: "bob"},
+						Parents:                 []string{"reviewed1"},
+						ChangedFilesIfAvailable: nil,
+					},
+				},
+				ApproversByCommit: map[string]map[string]*github.User{
+					"reviewed1": {
+						"carol": {Login: "carol"},
+					},
+				},
+			},
+			mock: &mockGitHub{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := &Controller{gh: tt.mock}
+			ev := &Event{RepoOwner: "owner", RepoName: "repo"}
+			got := ctrl.findCarryForwardApprovers(context.Background(), discardLogger, ev, tt.pr)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("findCarryForwardApprovers() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/check.go
+++ b/pkg/controller/check.go
@@ -21,7 +21,11 @@ func (c *Controller) newCheckRunInput(logger *slog.Logger, ev *Event, result *va
 	switch result.State {
 	case validation.StateApproved:
 		conclusion = githubv4.CheckConclusionStateSuccess
-		title = githubv4.String("Approved")
+		if result.CarriedForward {
+			title = githubv4.String("Approved (carried forward)")
+		} else {
+			title = githubv4.String("Approved")
+		}
 	case validation.StateApprovalIsRequired:
 		conclusion = githubv4.CheckConclusionStateFailure
 		title = githubv4.String("Approvals are required")

--- a/pkg/controller/ignore.go
+++ b/pkg/controller/ignore.go
@@ -5,6 +5,14 @@ import (
 )
 
 func ignore(logger *slog.Logger, ev *Event) bool {
+	// For pull_request events, only process "synchronize" action.
+	if ev.EventType == eventPullRequest {
+		if ev.Action != "synchronize" {
+			logger.Info("ignore the pull_request event because the action is not 'synchronize'", "action", ev.Action)
+			return true
+		}
+		return false
+	}
 	if ev.Action == "edited" {
 		logger.Info("ignore the event because the action is 'edited'")
 		return true

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/suzuki-shunsuke/slog-error/slogerr"
 	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/config"
+	"github.com/suzuki-shunsuke/validate-pr-review-app/pkg/validation"
 )
 
 func (c *Controller) Run(ctx context.Context, logger *slog.Logger, req *Request) error {
@@ -42,7 +43,16 @@ func (c *Controller) Run(ctx context.Context, logger *slog.Logger, req *Request)
 	trust.Init()
 
 	// Run validation
-	result := c.validate(ctx, logger, ev, &trust, &insecure)
+	var result *validation.Result
+	if ev.EventType == eventPullRequest {
+		result = c.carryForwardCheck(ctx, logger, ev, &trust, &insecure)
+		if result == nil {
+			logger.Info("carry-forward check not applicable, skipping")
+			return nil
+		}
+	} else {
+		result = c.validate(ctx, logger, ev, &trust, &insecure)
+	}
 	result.RequestID = req.RequestID
 
 	if err := c.gh.CreateCheckRun(ctx, c.newCheckRunInput(logger, ev, result, &trust, &insecure)); err != nil {

--- a/pkg/controller/verify_webhook.go
+++ b/pkg/controller/verify_webhook.go
@@ -24,6 +24,7 @@ const (
 	headerXHubSignature                   = "X-HUB-SIGNATURE"
 	headerXGitHubEvent                    = "X-GITHUB-EVENT"
 	eventPullRequestReview                = "pull_request_review"
+	eventPullRequest                      = "pull_request"
 	eventInstallation                     = "installation"
 	eventCheckSuite                       = "check_suite"
 )
@@ -44,7 +45,7 @@ func (c *Controller) normalizeHeaders(headers map[string]string) map[string]stri
 	return hs
 }
 
-func (c *Controller) verifyWebhook(logger *slog.Logger, req *Request) *Event {
+func (c *Controller) verifyWebhook(logger *slog.Logger, req *Request) *Event { //nolint:cyclop
 	headers := c.normalizeHeaders(req.Headers)
 	body := []byte(req.Body)
 	if err := c.verifySignature(body, headers); err != nil {
@@ -65,6 +66,13 @@ func (c *Controller) verifyWebhook(logger *slog.Logger, req *Request) *Event {
 			return nil
 		}
 		return newPullRequestReviewEvent(payload)
+	case eventPullRequest:
+		payload := &github.PullRequestEvent{}
+		if err := json.Unmarshal(body, payload); err != nil {
+			logger.Warn("parse a webhook payload", "error", err)
+			return nil
+		}
+		return newPullRequestEvent(payload)
 	case eventCheckSuite:
 		payload := &github.CheckSuiteEvent{}
 		if err := json.Unmarshal(body, payload); err != nil {
@@ -86,6 +94,7 @@ func (c *Controller) verifyWebhook(logger *slog.Logger, req *Request) *Event {
 }
 
 type Event struct {
+	EventType    string
 	Action       string
 	RepoFullName string
 	RepoOwner    string
@@ -98,12 +107,26 @@ type Event struct {
 
 func newPullRequestReviewEvent(ev *github.PullRequestReviewEvent) *Event {
 	return &Event{
+		EventType:    eventPullRequestReview,
 		Action:       ev.GetAction(),
 		RepoFullName: ev.GetRepo().GetFullName(),
 		RepoOwner:    ev.GetRepo().GetOwner().GetLogin(),
 		RepoName:     ev.GetRepo().GetName(),
 		PRNumber:     ev.GetPullRequest().GetNumber(),
 		ReviewState:  ev.GetReview().GetState(),
+		RepoID:       ev.GetRepo().GetNodeID(),
+		HeadSHA:      ev.GetPullRequest().GetHead().GetSHA(),
+	}
+}
+
+func newPullRequestEvent(ev *github.PullRequestEvent) *Event {
+	return &Event{
+		EventType:    eventPullRequest,
+		Action:       ev.GetAction(),
+		RepoFullName: ev.GetRepo().GetFullName(),
+		RepoOwner:    ev.GetRepo().GetOwner().GetLogin(),
+		RepoName:     ev.GetRepo().GetName(),
+		PRNumber:     ev.GetPullRequest().GetNumber(),
 		RepoID:       ev.GetRepo().GetNodeID(),
 		HeadSHA:      ev.GetPullRequest().GetHead().GetSHA(),
 	}
@@ -144,6 +167,7 @@ func newCheckSuiteEvent(logger *slog.Logger, ev *github.CheckSuiteEvent) (*Event
 		return nil, nil //nolint:nilnil
 	}
 	return &Event{
+		EventType:    eventCheckSuite,
 		Action:       ev.GetAction(),
 		RepoFullName: ev.GetRepo().GetFullName(),
 		RepoOwner:    ev.GetRepo().GetOwner().GetLogin(),

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -26,6 +26,7 @@ type V3Client interface {
 
 type (
 	PullRequestReviewEvent = github.PullRequestReviewEvent
+	PullRequestEvent       = github.PullRequestEvent
 	CheckSuiteEvent        = github.CheckSuiteEvent
 	ParamNewApp            = v4.ParamNewApp
 )

--- a/pkg/github/get_pr.go
+++ b/pkg/github/get_pr.go
@@ -18,41 +18,60 @@ func (c *Client) GetPR(ctx context.Context, owner, name string, number int) (*Pu
 	for i, v := range pr.Commits.Nodes {
 		commits[i] = newCommit(v)
 	}
-	// filter reviews
-	// Get the latest review for each user
-	reviews := make(map[string]*v4.Review, len(pr.Reviews.Nodes))
-	for _, node := range pr.Reviews.Nodes {
-		if node.Commit.OID != pr.HeadRefOID {
-			// Exclude reviews for non head commits
-			continue
-		}
+
+	reviewsByCommit := groupReviewsByCommit(pr.Reviews.Nodes)
+	approversByCommit := buildApproversByCommit(reviewsByCommit)
+
+	p := &PullRequest{
+		HeadSHA:           pr.HeadRefOID,
+		Commits:           commits,
+		Approvers:         approversByCommit[pr.HeadRefOID],
+		ApproversByCommit: approversByCommit,
+	}
+	if p.Approvers == nil {
+		p.Approvers = make(map[string]*User)
+	}
+	return p, nil
+}
+
+// groupReviewsByCommit groups reviews by commit OID,
+// keeping only the latest review per user per commit.
+func groupReviewsByCommit(nodes []*v4.Review) map[string]map[string]*v4.Review {
+	reviewsByCommit := make(map[string]map[string]*v4.Review)
+	for _, node := range nodes {
 		review := newReview(node)
 		login := review.Author.Login
 		if login == "" {
-			// Skip reviews from deleted users
 			continue
 		}
-		if a, ok := reviews[login]; ok {
-			// Keep the latest review
+		commitOID := node.Commit.OID
+		if reviewsByCommit[commitOID] == nil {
+			reviewsByCommit[commitOID] = make(map[string]*v4.Review)
+		}
+		if a, ok := reviewsByCommit[commitOID][login]; ok {
 			if node.CreatedAt.Before(a.CreatedAt.Time) {
 				continue
 			}
-			reviews[login] = node
-			continue
 		}
-		reviews[login] = node
+		reviewsByCommit[commitOID][login] = node
 	}
-	m := make(map[string]*User, len(reviews))
-	for k, v := range reviews {
-		if v.State != "APPROVED" {
-			continue
+	return reviewsByCommit
+}
+
+// buildApproversByCommit converts grouped reviews to approvers maps,
+// filtering to only APPROVED reviews.
+func buildApproversByCommit(reviewsByCommit map[string]map[string]*v4.Review) map[string]map[string]*User {
+	approversByCommit := make(map[string]map[string]*User, len(reviewsByCommit))
+	for oid, reviews := range reviewsByCommit {
+		m := make(map[string]*User)
+		for k, v := range reviews {
+			if v.State == "APPROVED" {
+				m[k] = newUser(v.Author)
+			}
 		}
-		m[k] = newUser(v.Author)
+		if len(m) > 0 {
+			approversByCommit[oid] = m
+		}
 	}
-	p := &PullRequest{
-		HeadSHA:   pr.HeadRefOID,
-		Commits:   commits,
-		Approvers: m,
-	}
-	return p, nil
+	return approversByCommit
 }

--- a/pkg/github/pull_request.go
+++ b/pkg/github/pull_request.go
@@ -1,9 +1,10 @@
 package github
 
 type PullRequest struct {
-	HeadSHA   string           `json:"sha"`
-	Approvers map[string]*User `json:"approvers"`
-	Commits   []*Commit        `json:"commits"`
+	HeadSHA           string                      `json:"sha"`
+	Approvers         map[string]*User            `json:"approvers"`
+	ApproversByCommit map[string]map[string]*User `json:"approvers_by_commit"`
+	Commits           []*Commit                   `json:"commits"`
 }
 
 type Author struct {

--- a/pkg/validation/run.go
+++ b/pkg/validation/run.go
@@ -168,11 +168,12 @@ func (c *Validator) VerifyCommit(commit *github.Commit, trust *Trust, insecure *
 }
 
 type Result struct {
-	RequestID     string
-	Error         string
-	State         State
-	Approvers     []string
-	SelfApprovers map[string]struct{}
+	RequestID      string
+	Error          string
+	State          State
+	CarriedForward bool
+	Approvers      []string
+	SelfApprovers  map[string]struct{}
 	// app or untrusted machine user approvals
 	IgnoredApprovers []*github.IgnoredApproval
 	// app


### PR DESCRIPTION
## Summary

When someone pushes a merge commit (e.g., "Update branch") or empty commit to a PR, no `pull_request_review` event fires, so no check is created on the new HEAD. If the check is required by branch protection, the PR gets stuck — even though the new commit can't introduce malicious changes.

This PR subscribes to `pull_request.synchronize` events and carries forward the validation result from the most recent reviewed commit when all new commits are harmless (empty or clean merge).

### Changes

- **`pkg/controller/verify_webhook.go`**: Add `pull_request` event parsing with `EventType` field on `Event` struct. Set `EventType` on all event constructors (`pull_request_review`, `pull_request`, `check_suite`)
- **`pkg/github/client.go`**: Add `PullRequestEvent` type alias
- **`pkg/github/pull_request.go`**: Add `ApproversByCommit map[string]map[string]*User` field — reviews grouped by commit OID
- **`pkg/github/get_pr.go`**: Refactor review processing into `groupReviewsByCommit()` and `buildApproversByCommit()` helpers. Populate both `Approvers` (HEAD reviews, existing behavior) and `ApproversByCommit` (all commits)
- **`pkg/controller/ignore.go`**: For `pull_request` events, only process `synchronize` action
- **`pkg/controller/run.go`**: Branch on `ev.EventType` — route `pull_request` events to carry-forward logic, others to existing validation
- **`pkg/controller/carry_forward.go`** (new): Core carry-forward logic:
  - `carryForwardCheck()`: Fetches PR, guards against stale webhooks (compares event SHA vs current PR HEAD), finds carried-forward approvers, runs full validation with those approvers
  - `findCarryForwardApprovers()`: Walks commits from HEAD (newest) to oldest. For each commit: if it has reviews → return those approvers; if empty (`changedFilesIfAvailable == 0`) or clean merge (no overlapping files) → continue; otherwise → return nil (can't carry forward)
- **`pkg/controller/check.go`**: When `CarriedForward` is true and state is approved, title shows "Approved (carried forward)"
- **`pkg/validation/run.go`**: Add `CarriedForward bool` field to `Result`
- **`pkg/controller/carry_forward_internal_test.go`** (new): 7 test cases covering empty commit, clean merge, regular commit blocked, no reviews, multiple empty commits, conflict-resolution merge blocked, nil changedFilesIfAvailable

### Design decisions

- **Only clean merge commits** (no conflict resolution) qualify — reuses existing `isCleanMergeCommit` logic
- **Applies to any commit**, not just approver commits (unlike `checkApproverCommits`)
- **Fail closed**: null `changedFilesIfAvailable`, API errors, conflict-resolution merges all block carry-forward
- **Stale webhook guard**: Compares `ev.HeadSHA` with `pr.HeadSHA` from GraphQL to ignore redelivered webhooks
- **Full validation on carry-forward**: The carried-forward approvers go through the same `checkApproverCommits` + `validator.Run` flow, so self-approval and untrusted commit checks still apply

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] `go run ./cmd/gen-jsonschema` passes
- [x] Test: HEAD is empty, previous commit reviewed → approved (carried forward)
- [x] Test: HEAD is clean merge, previous commit reviewed → approved (carried forward)
- [x] Test: HEAD is regular commit → nil (no check created)
- [x] Test: No reviewed commits → nil
- [x] Test: Multiple empty/merge commits walk back to reviewed commit
- [x] Test: Conflict-resolution merge → nil (blocked)
- [x] Test: nil changedFilesIfAvailable with single parent → nil (fail closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)