### PR TITLE
fix: reject octopus merge commits (3+ parents) as non-clean

### DIFF
--- a/pkg/controller/merge_commit.go
+++ b/pkg/controller/merge_commit.go
@@ -50,7 +50,7 @@ const maxCompareFiles = 300
 // diffs to the merge commit have no overlapping files (i.e., no conflict resolution)
 // and whose non-PR parents are ancestors of the base branch.
 func (c *Controller) isCleanMergeCommit(ctx context.Context, logger *slog.Logger, ev *Event, commit *github.Commit, prCommitSHAs map[string]struct{}, prBaseSHA string) bool { //nolint:cyclop
-	if len(commit.Parents) < 2 { //nolint:mnd
+	if len(commit.Parents) != 2 { //nolint:mnd
 		return false
 	}
 

--- a/pkg/controller/merge_commit_internal_test.go
+++ b/pkg/controller/merge_commit_internal_test.go
@@ -152,39 +152,23 @@ func Test_isCleanMergeCommit(t *testing.T) { //nolint:funlen
 			want:         false,
 		},
 		{
-			name: "octopus merge (3 parents, no overlap, base branch parents)",
+			name: "octopus merge (3 parents) rejected",
 			commit: &github.Commit{
 				SHA:     "merge123",
 				Parents: []string{"parent1", "parent2", "parent3"},
 			},
-			mock: &mockGitHub{
-				compareResult: map[string][]string{
-					"parent1...merge123": {"file_a.go"},
-					"parent2...merge123": {"file_b.go"},
-					"parent3...merge123": {"file_c.go"},
-				},
-				ancestorResult: map[string]bool{
-					"parent2...base-sha": true,
-					"parent3...base-sha": true,
-				},
-			},
+			mock:         &mockGitHub{},
 			prCommitSHAs: defaultPRCommitSHAs,
 			baseSHA:      defaultBaseSHA,
-			want:         true,
+			want:         false,
 		},
 		{
-			name: "octopus merge (3 parents, overlap between non-adjacent)",
+			name: "octopus merge (3 parents, overlap) also rejected",
 			commit: &github.Commit{
 				SHA:     "merge123",
 				Parents: []string{"parent1", "parent2", "parent3"},
 			},
-			mock: &mockGitHub{
-				compareResult: map[string][]string{
-					"parent1...merge123": {"file_a.go"},
-					"parent2...merge123": {"file_b.go"},
-					"parent3...merge123": {"file_a.go"},
-				},
-			},
+			mock:         &mockGitHub{},
 			prCommitSHAs: defaultPRCommitSHAs,
 			baseSHA:      defaultBaseSHA,
 			want:         false,


### PR DESCRIPTION
## Summary

- Reject merge commits with 3+ parents (octopus merges) in `isCleanMergeCommit`
- Change `len(commit.Parents) < 2` to `len(commit.Parents) != 2` in `pkg/controller/merge_commit.go`
- Simplify octopus merge test cases since they are now rejected at the parent count check

## Context

A legitimate "Update branch" merge commit always has exactly 2 parents: one from the PR branch HEAD and one from the base branch HEAD. Octopus merges (3+ parents) merge additional branches beyond the base branch, potentially introducing unreviewed code that could bypass the two-approval requirement.

## Test plan

- [x] `cmdx v` passes
- [x] `cmdx t` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)