### PR TITLE
docs: add documentation for empty commits, trivial merge commits, and PR event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ It helps organizations improve governance and security by ensuring PRs cannot be
 
 - At least **1 approval** required.
 - If the committer approves → **2 approvals required**.
+  - [As of v0.3.2, empty commits and trivial merge commits don't require 2 approvals](docs/allow-empty-commit-and-trivial-merge-commit.md)
 - If the PR contains [unsigned commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) or [commits not linked to a GitHub user](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/troubleshooting-commits/why-are-my-commits-linked-to-the-wrong-user) → **2 approvals required**.
 - Approvals from untrusted Machine Users or GitHub Apps are ignored.
 - If the PR contains commits from untrusted Machine Users or GitHub Apps → **2 approvals required**.
+- [See also Handling Pull Request Events](docs/handle-pull-request-event.md)
 
 ## How It Works
 
@@ -40,7 +42,7 @@ sequenceDiagram
     participant GitHub
     participant ValidatePRReviewApp as Validate PR Review App
 
-    GitHub ->> ValidatePRReviewApp: Send Pull Request Review Webhook
+    GitHub ->> ValidatePRReviewApp: Send Pull Request Review or Pull Request Webhook
     ValidatePRReviewApp ->> ValidatePRReviewApp: Validate Webhook
     ValidatePRReviewApp ->> ValidatePRReviewApp: Ignore irrelevant events
     ValidatePRReviewApp ->> GitHub: Fetch PR reviews and commits (GitHub API)

--- a/docs/allow-empty-commit-and-trivial-merge-commit.md
+++ b/docs/allow-empty-commit-and-trivial-merge-commit.md
@@ -1,0 +1,37 @@
+# Allow Empty Commits and Trivial Merge Commits
+
+As of v0.3.2, validate-pr-review-app doesn't require 2 approvals for empty commits and trivial merge commits by approvers.
+
+## What are trivial merge commits?
+
+When a PR's base branch can be merged into the feature branch without any conflict resolution, the resulting merge commit is referred to here as a "trivial merge commit".
+The term "trivial merge" is inspired by the following documentation, but the definition of a trivial merge commit in validate-pr-review-app is not strictly the same.
+
+https://git-scm.com/docs/trivial-merge
+
+## Why?
+
+To prevent PRs from being merged without review by others, validate-pr-review-app requires approval from someone other than the approver if the approver has commits in the PR.
+However, empty commits and trivial merge commits do not contain changes that need to be reviewed.
+Empty commits obviously have no changes, and the changes in trivial merge commits are already included in the base branch, so merging them into the base branch causes no issues.
+Therefore, since v0.3.2, even if these commits are present, a second approval is no longer required.
+
+## How are trivial merge commits detected?
+
+Here is how validate-pr-review-app determines whether a commit is a trivial merge commit.
+Since validate-pr-review-app does not depend on Git, it retrieves commit information via the GitHub API.
+Note that this results in GitHub API calls that consume rate limits.
+
+First, when fetching PR commits and reviews via the GraphQL API, the number of changed files (`changedFilesIfAvailable`) and parent SHAs are also retrieved.
+If `changedFilesIfAvailable` is 0, the commit is an empty commit.
+Next, the number of parents is checked to ensure there are exactly 2.
+A trivial merge commit always has exactly two parents: the first parent (the previous commit on the feature branch) and a commit from the PR's base branch.
+If there are 3 or more parents, branches other than the base branch have been merged, which means unreviewed changes may be included and review is required.
+The diffs between each parent SHA and the commit are retrieved using the [Compare two commits API](https://docs.github.com/en/rest/commits/commits), and the changed files are checked for overlaps.
+If there are overlapping files, conflict resolution has likely occurred, and review is needed to verify the resolution is correct.
+Strictly speaking, different parts of the same file may have been modified without causing a conflict, but checking whether code changes overlap at the line level via the API would be overly complex. So as a safety measure, if the same file appears in both diffs, review is required.
+Due to API limitations, the maximum number of files that can be retrieved is 300. If 300 or more files are changed, it is treated conservatively as having overlaps, and review is required.
+If a file other than the merged branch's files is modified when generating the merge commit, that file's diff appears in both the diff against the base branch and the diff against the first parent, resulting in an overlap.
+Additionally, the non-first parent is compared with the HEAD of the PR's base branch using the [Compare two commits API](https://docs.github.com/en/rest/commits/commits) to check whether the parent is an ancestor of the HEAD.
+If `behindBy` is 0, it is an ancestor.
+If the parent is not a commit from the base branch, it means another feature branch was merged, and review is required.

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -12,6 +12,7 @@
 - [Create a private key](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps)
 - Subscribe Events
   - Pull request review
+  - Pull request (As of v0.3.2)
 
 After registering the app, you can get the app id from the setting page.
 Please add it to config.yaml.

--- a/docs/handle-pull-request-event.md
+++ b/docs/handle-pull-request-event.md
@@ -1,0 +1,80 @@
+# Handling Pull Request Events
+
+Previously, validate-pr-review-app only subscribed to Pull Request Review Events.
+Starting with v0.3.2, it can also subscribe to Pull Request Events.
+Because only Pull Request Review Events were subscribed to before, pushing empty commits or trivial merge commits to an already-approved PR would not create a validate-pr-review-app check on the pushed commit, requiring an additional approval and degrading the developer experience.
+By subscribing to Pull Request Events, validate-pr-review-app creates a check on the pushed commit without requiring an additional approval.
+validate-pr-review-app only handles the `synchronize` action of Pull Request Events and ignores all other actions.
+If the target commit has reviews, the reviews are validated using the same logic as before.
+If there are no reviews and the target commit is neither an empty commit nor a trivial merge commit, no check is created.
+[See Allow Empty Commits and Trivial Merge Commits for details about empty commits and trivial merge commits.](allow-empty-commit-and-trivial-merge-commit.md)
+
+If the target commit is an empty commit or a trivial merge commit, validate-pr-review-app walks back through the parent commits on the PR's head branch using the same logic, and creates a check on the target commit.
+
+Here is a more concrete explanation.
+
+1. Suppose a PR containing commit 1 has been approved.
+
+```
+commit 1: approved <- HEAD
+```
+
+2. Performing an "update branch" and generating commit 2.
+
+```
+commit 1: approved
+commit 2: update branch (trivial merge commit) <- HEAD
+```
+
+validate-pr-review-app checks commit 2.
+Since commit 2 has no approvals and is a trivial merge commit, it checks the parent commit 1.
+Because commit 1 is approved, validate-pr-review-app marks commit 2 as success.
+
+```
+commit 1: approved
+commit 2: success <- HEAD
+```
+
+3. Pushing an empty commit 3.
+
+```
+commit 1: approved
+commit 2: trivial merge commit
+commit 3: empty commit <- HEAD
+```
+
+validate-pr-review-app again walks back through the commits to commit 1, and marks commit 3 as success.
+
+4. Suppose the PR has a conflict, which is resolved and the branch is updated.
+
+```
+commit 1: approved
+commit 2: trivial merge commit
+commit 3: empty commit
+commit 4: resolve conflict <- HEAD
+```
+
+validate-pr-review-app checks commit 4, but since it is neither a trivial merge commit nor an empty commit, no check is created.
+Review is required.
+
+5. Pushing an empty commit again.
+
+```
+commit 1: approved
+commit 2: trivial merge commit
+commit 3: empty commit
+commit 4: resolve conflict
+commit 5: empty commit <- HEAD
+```
+
+validate-pr-review-app walks back through the commits to commit 4, but since commit 4 is not approved and is neither a trivial merge commit nor an empty commit, no check is created.
+
+6. Approving commit 5 and merging a different feature branch into the PR's feature branch.
+
+```
+commit 1 ~ 4: omitted
+commit 5: approved
+commit 6: merge other feature branch <- HEAD
+```
+
+Although commit 6 is a merge commit, it does not merge the PR's base branch, so no check is created.


### PR DESCRIPTION
## Summary

- Add `docs/allow-empty-commit-and-trivial-merge-commit.md`: explains why and how validate-pr-review-app skips the second approval requirement for empty commits and trivial merge commits (as of v0.3.2), including the detection logic using GitHub's GraphQL and Compare two commits APIs
- Add `docs/handle-pull-request-event.md`: explains the new Pull Request Event (`synchronize` action) subscription added in v0.3.2, including the carry-forward logic that walks back through parent commits to reuse prior approvals when only empty/trivial merge commits are added
- Update `README.md`: add links to the new docs and update the sequence diagram to reflect that Pull Request webhooks are also handled
- Update `docs/github-app.md`: add "Pull request" to the list of subscribed events

🤖 Generated with [Claude Code](https://claude.com/claude-code)