### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,12 +5,14 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
-      - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
+      - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: terraform fmt -recursive
         working-directory: terraform/aws
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
       id-token: write
       actions: read
       attestations: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
 
   release-image:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,3 +17,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,12 +1,19 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the Go release, test, and autofix GitHub Actions workflows.

## Changes

- `.github/workflows/release.yaml`: Added `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `release` job (go-release-workflow already pinned at v8.1.0).
- `.github/workflows/workflow_call_test.yaml`: Bumped go-test-full-workflow ref from `v5.0.2` (`e442a17816baa8a940edc1544cc6e739d870e165`) to `v6.0.0` (`98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb`); declared the `TAKUMI_GUARD_BOT_ID` secret as required on `on: workflow_call`; added `id-token: write` and a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `test` job.
- `.github/workflows/test.yaml`: On the `test` job that calls the reusable `./.github/workflows/workflow_call_test.yaml`, added `id-token: write` permission and a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to plumb the secret to the reusable workflow.
- `.github/workflows/autofix.yaml`: Bumped go-autofix-action ref from `v0.1.12` (`ba716cebb7767055bdde0e62bb91d715bde39ab2`) to `v0.1.13` (`9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e`); added input `takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}`; added `id-token: write` to the `autofix` job permissions.

## Note

The reusable workflow bump of go-test-full-workflow crossed a MAJOR version (v5 -> v6).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository (or organization) settings for these workflows to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)